### PR TITLE
show--correct answer feature now works when question is changed

### DIFF
--- a/src/actions/ShowCorrectAnswer.js
+++ b/src/actions/ShowCorrectAnswer.js
@@ -8,18 +8,27 @@ class ShowCorrectAnswer extends Component {
   componentDidMount() {
     this.whenWrongClick()
   }
+
   whenWrongClick = () => {
-    const correctAnswer = this.props.correctAnswer //string
-    const boolean = this.props.answer //true or false
-    if (boolean === false) {   //IDEA: CAN WE USE ANOTHER ACTION IN AN IF STATEMENT
-      this.props.dispatch({
-        type: 'SHOW_CORRECT_ANSWER',
-        payload: correctAnswer
-      })
-    }
+    // const correctAnswer = this.props.correctAnswer //string
+    // const boolean = this.props.answer //true or false
+    // if (boolean === false) {
+    //   this.setState({ answer: null  })
+    //   console.log(this.state.answer, 'Iamstateanswer')
+    //   this.props.dispatch({
+    //     type: 'SHOW_CORRECT_ANSWER',
+    //     payload: correctAnswer
+    //   })
+    // }
   }
+
+  shouldDisplayCorrectAnswer(){
+    return this.props.answer !== null && !this.props.answer.state
+  }
+
   render() {
     console.log(this.props.answer)
+    console.log(this.state)
     if (this.props.answer) {
       return (<div><p>{this.props.correctAnswer}</p></div>)
     }
@@ -30,9 +39,8 @@ class ShowCorrectAnswer extends Component {
 
 const mapStateToProps = (state) => {
   return {
-    answer: state.answerBoolean,
+    answer: state.showCorrectAnswer
   }
 }
-
 
 export default connect(mapStateToProps)(ShowCorrectAnswer)

--- a/src/components/MainView.js
+++ b/src/components/MainView.js
@@ -20,8 +20,11 @@ class MainView extends React.Component {
         this.props.dispatch({
           type:'INCORRECT_ANSWER',
           payload: false
-       }
-      )  
+       })
+
+       this.props.dispatch({
+         type:'SHOW_CORRECT_ANSWER'
+      })
 		} }
 
 	render(){
@@ -37,7 +40,7 @@ class MainView extends React.Component {
               <li value={this.props.answer2} onClick={this.handleClick}>{this.props.answer2}</li>
               <li value={this.props.answer3} onClick={this.handleClick}>{this.props.answer3}</li>
             </ul>
-            <ShowCorrectAnswer correctAnswer={this.props.correctAnswer}/>
+            <ShowCorrectAnswer correctAnswer={this.props.correctAnswer} answerBoolean={this.props.answerBoolean}/>
             </div>
         )
     }
@@ -46,7 +49,8 @@ class MainView extends React.Component {
 
 const mapStateToProps = (state) => {
     return {
-        state
+        state,
+        answerBoolean: state.answerBoolean
     }
 }
 

--- a/src/reducers/DisplayImage.js
+++ b/src/reducers/DisplayImage.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux'
 import MainView from '../components/MainView'
 
 class DisplayImage extends Component {
-  state = { 
+  state = {
     image: null,
   }
 
@@ -13,9 +13,8 @@ class DisplayImage extends Component {
   }
 
   nextQuestion() {
-    console.log(this.props.breeds,'im breeds in nextQuestion')
-    console.log('nextQuestion is called')
-    
+
+
     let lengthBreedsArray = this.props.breeds.length
     const randomNumber1 = Math.floor(Math.random()*lengthBreedsArray)
     const randomNumber2 = Math.floor(Math.random()*lengthBreedsArray)
@@ -35,6 +34,8 @@ class DisplayImage extends Component {
     },
     () => {this.getImage()}
     )
+
+    this.props.dispatch({ type: 'SHOW_NOTHING' })
   }
 
 getImage = () => {
@@ -45,8 +46,8 @@ getImage = () => {
         image:res
       }))
       .catch(console.err)
-  } 
-  
+  }
+
   render() {
     const { breeds } = this.props
     if (breeds) {
@@ -58,7 +59,7 @@ getImage = () => {
             answer1={breeds[this.state.randomNumber1]}
             answer2={breeds[this.state.randomNumber2]}
             answer3={breeds[this.state.randomNumber3]}
-        
+
             nextQuestion={() => this.nextQuestion()}
             />
           </div>

--- a/src/reducers/ShowCorrectAnswerReducer.js
+++ b/src/reducers/ShowCorrectAnswerReducer.js
@@ -1,7 +1,10 @@
 const ShowCorrectAnswerReducer = (state = initialState, action = {}) => {
   switch (action.type) {
     case 'SHOW_CORRECT_ANSWER':
-    return action.payload
+    return true
+
+    case 'SHOW_NOTHING':
+    return false
 
   default:
     return state
@@ -9,4 +12,4 @@ const ShowCorrectAnswerReducer = (state = initialState, action = {}) => {
 }
 export default ShowCorrectAnswerReducer
 
-const initialState = []
+const initialState = false

--- a/src/reducers/answerBoolean.js
+++ b/src/reducers/answerBoolean.js
@@ -7,10 +7,10 @@ const answerBoolean = ( state=null, action) => {
     case 'INCORRECT_ANSWER':
       return {
         state: action.payload
-      }  
-      default: 
+      }
+      default:
           return state
   }
 }
-  
+
 export default answerBoolean

--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -5,7 +5,7 @@ import performanceBar from './performanceBarReducer'
 // import reducer from './reducer'
 import levelUpReducer from './levelUpReducer'
 import answerBoolean from './answerBoolean'
-import ShowCorrectAnswerReducer from './ShowCorrectAnswerReducer'
+import showCorrectAnswer from './ShowCorrectAnswerReducer'
 
 export default combineReducers({
     // reducer,
@@ -13,5 +13,5 @@ export default combineReducers({
     answerBoolean,
     DisplayContentReducer,
     performanceBar,
-    ShowCorrectAnswerReducer
+    showCorrectAnswer
 })


### PR DESCRIPTION
Fixed the bug where the correct answer was being displayed even if user has not chosen the answer yet. Now when the page is rerendered upon the next question, the correct answer is only shown if the user clicks on the wrong answer.